### PR TITLE
CORE-998: added up and down migrations for schema version 2

### DIFF
--- a/migrations/000002_add_outgoing.down.sql
+++ b/migrations/000002_add_outgoing.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE ONLY notifications
+DROP COLUMN routing_key;
+
+ALTER TABLE ONLY notifications
+DROP COLUMN outgoing_json;
+
+ALTER TABLE ONLY notifications
+RENAME COLUMN incoming_json TO message;

--- a/migrations/000002_add_outgoing.up.sql
+++ b/migrations/000002_add_outgoing.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE ONLY notifications
+RENAME COLUMN message TO incoming_json;
+
+ALTER TABLE ONLY notifications
+ADD COLUMN outgoing_json jsonb;
+
+ALTER TABLE ONLY notifications
+ADD COLUMN routing_key varchar(64);
+
+UPDATE notifications
+SET outgoing_json = jsonb_set(incoming_json, '{message,id}', to_jsonb(id));


### PR DESCRIPTION
Schema version 2 has the following changes:

- The `message` column has been renamed to `incoming_json`.
- A new column `outgoing_json` has been added. The purpose of this column is to record the outgoing notification JSON.
- A new column `routing_key` has been added. This column is used to record the AMQP routing key, which can help us to determine which message handler was used in the `event_recorder` service. This column is nullable. Messages that were migrated from the original notification agent will have a null value in this column.
